### PR TITLE
Corrected a 'race' condition

### DIFF
--- a/src/Component.cpp
+++ b/src/Component.cpp
@@ -5,9 +5,10 @@
 #include "Component.h"
 
 Component::Component(int pin, String componentType){
-  Serial.println("Component "+componentType + "is set at pin "+pin);
+  Serial.println("Component " + componentType + " is set at pin " + pin);
   _pin = pin;
   _componentType = componentType;
+  delay(100);
 }
 
 Component::Component(){


### PR DESCRIPTION
I noticed that most of the time I would launch the program it would freeze during the initialization of the components. It would successfully initialize some of them and then freeze. I'm not sure where the issue is coming into play, but ading this very small delay fixes the problem. This seems to suggest that there is some sort of 'race' condition hidden in there somewhere. For such an easy fix/workaround it probably isn't worth any further investment into figuring out why.

(Also fixed some formatting of the println(). )