### PR TITLE
Add debug logging back in

### DIFF
--- a/src/Alarm.cpp
+++ b/src/Alarm.cpp
@@ -24,6 +24,7 @@ void Alarm::calibrate(){
     alertSuccessfulAction();
     _isCalibrated = true;
   }
+  Serial.println("Alarm is calibrating");
 }
 
 void Alarm::determineBasePhotoresistorReading(){
@@ -36,16 +37,19 @@ void Alarm::determineBasePhotoresistorReading(){
   }
   _baseReading = avgReading / numOfReadings;
   _laser->on();
+  Serial.println("Alam is determining base read of Photoresistor");
 }
 
 void Alarm::alertFailedAction(){
   _buzzer->soundNegativeTone();
   _redLED->flash(3000);
+  Serial.println("Alarm failed to arm");
 }
 
 void Alarm::alertSuccessfulAction(){
   _buzzer->soundAffirmativeTone();
   _greenLED->flash(3000);
+  Serial.println("Alarm is armed");
 }
 
 void Alarm::arm(){
@@ -71,6 +75,7 @@ bool Alarm::isArmed(){
 }
 
 bool Alarm::isTripped(){
+    Serial.println("Alarm is tripped");
   return (_photoR->takeReading() - 100 < _baseReading);
 }
 
@@ -98,12 +103,14 @@ bool Alarm::isTriggered(){
 void Alarm::disarm(){
   _isTriggered = false;
   _isArmed = false;
+  Serial.println("Alarm is disarmed");
 }
 void Alarm::silence(){
 
 }
 
 bool Alarm::isCalibrated(){
+  Serial.println("Alarm is calibrated");
   return _isCalibrated;
 }
 

--- a/src/Alarm.cpp
+++ b/src/Alarm.cpp
@@ -24,7 +24,7 @@ void Alarm::calibrate(){
     alertSuccessfulAction();
     _isCalibrated = true;
   }
-  Serial.println("Alarm is calibrating");
+  if(Properties::DEBUGGING_ACTIVE) Serial.println("Alarm is calibrating");
 }
 
 void Alarm::determineBasePhotoresistorReading(){
@@ -37,19 +37,19 @@ void Alarm::determineBasePhotoresistorReading(){
   }
   _baseReading = avgReading / numOfReadings;
   _laser->on();
-  Serial.println("Alam is determining base read of Photoresistor");
+  if(Properties::DEBUGGING_ACTIVE) Serial.println("Alam is determining base read of Photoresistor");
 }
 
 void Alarm::alertFailedAction(){
   _buzzer->soundNegativeTone();
   _redLED->flash(3000);
-  Serial.println("Alarm failed to arm");
+  if(Properties::DEBUGGING_ACTIVE) Serial.println("Alarm failed to arm");
 }
 
 void Alarm::alertSuccessfulAction(){
   _buzzer->soundAffirmativeTone();
   _greenLED->flash(3000);
-  Serial.println("Alarm is armed");
+  if(Properties::DEBUGGING_ACTIVE) Serial.println("Alarm is armed");
 }
 
 void Alarm::arm(){
@@ -75,7 +75,7 @@ bool Alarm::isArmed(){
 }
 
 bool Alarm::isTripped(){
-    Serial.println("Alarm is tripped");
+    if(Properties::DEBUGGING_ACTIVE) Serial.println("Alarm is tripped");
   return (_photoR->takeReading() - 100 < _baseReading);
 }
 
@@ -103,14 +103,14 @@ bool Alarm::isTriggered(){
 void Alarm::disarm(){
   _isTriggered = false;
   _isArmed = false;
-  Serial.println("Alarm is disarmed");
+  if(Properties::DEBUGGING_ACTIVE) Serial.println("Alarm is disarmed");
 }
 void Alarm::silence(){
 
 }
 
 bool Alarm::isCalibrated(){
-  Serial.println("Alarm is calibrated");
+  if(Properties::DEBUGGING_ACTIVE) Serial.println("Alarm is calibrated");
   return _isCalibrated;
 }
 

--- a/src/Button.cpp
+++ b/src/Button.cpp
@@ -12,6 +12,7 @@ Button::Button(){
 }
 
 boolean Button::isPressed() {
+  Serial.println("Button has been pressed");
   boolean pressed = false;
   if (digitalRead(Component::getPin()) == HIGH) { // HIGH == Pressed
     pressed = true;

--- a/src/Button.cpp
+++ b/src/Button.cpp
@@ -12,7 +12,7 @@ Button::Button(){
 }
 
 boolean Button::isPressed() {
-  Serial.println("Button has been pressed");
+  if(Properties::DEBUGGING_ACTIVE) Serial.println("Button has been pressed");
   boolean pressed = false;
   if (digitalRead(Component::getPin()) == HIGH) { // HIGH == Pressed
     pressed = true;

--- a/src/Button.h
+++ b/src/Button.h
@@ -6,6 +6,8 @@
 
 #include "Arduino.h"
 #include "Component.h"
+#include "Properties.h"
+
 class Button : public Component{
 public:
   Button(int pin);

--- a/src/Buzzer.cpp
+++ b/src/Buzzer.cpp
@@ -12,6 +12,7 @@ Buzzer::Buzzer(){
 }
 
 void Buzzer::soundTone(int frequency) {
+  Serial.println("Buzzer has started sounding");
   tone(this->getPin(), frequency);
 }
 
@@ -39,5 +40,6 @@ void Buzzer::soundNegativeTone(){
 }
 
 void Buzzer::stopTone() {
+  Serial.println("Buzzer has stopped sounding");
   noTone(this->getPin());
 }

--- a/src/Buzzer.cpp
+++ b/src/Buzzer.cpp
@@ -12,7 +12,7 @@ Buzzer::Buzzer(){
 }
 
 void Buzzer::soundTone(int frequency) {
-  Serial.println("Buzzer has started sounding");
+  if(Properties::DEBUGGING_ACTIVE) Serial.println("Buzzer has started sounding");
   tone(this->getPin(), frequency);
 }
 
@@ -40,6 +40,6 @@ void Buzzer::soundNegativeTone(){
 }
 
 void Buzzer::stopTone() {
-  Serial.println("Buzzer has stopped sounding");
+  if(Properties::DEBUGGING_ACTIVE) Serial.println("Buzzer has stopped sounding");
   noTone(this->getPin());
 }

--- a/src/Buzzer.h
+++ b/src/Buzzer.h
@@ -6,6 +6,7 @@
 
 #include "Arduino.h"
 #include "Component.h"
+#include "Properties.h"
 
 class Buzzer : public Component {
 public:

--- a/src/Component.cpp
+++ b/src/Component.cpp
@@ -5,6 +5,7 @@
 #include "Component.h"
 
 Component::Component(int pin, String componentType){
+  Serial.println("Component "+componentType + "is set at pin "+pin);
   _pin = pin;
   _componentType = componentType;
 }

--- a/src/Component.cpp
+++ b/src/Component.cpp
@@ -5,7 +5,7 @@
 #include "Component.h"
 
 Component::Component(int pin, String componentType){
-  Serial.println("Component "+componentType + "is set at pin "+pin);
+  if(Properties::DEBUGGING_ACTIVE) Serial.println("Component "+componentType + "is set at pin "+pin);
   _pin = pin;
   _componentType = componentType;
 }

--- a/src/Component.h
+++ b/src/Component.h
@@ -5,6 +5,7 @@
 #define Component_h
 
 #include "Arduino.h"
+#include "Properties.h"
 
 class Component{
   protected:

--- a/src/ComponentTester.cpp
+++ b/src/ComponentTester.cpp
@@ -27,17 +27,19 @@ void ComponentTester::testPin(){
   }
   if(componentType.equalsIgnoreCase("PHOTORESISTOR")){
     for(int i = 1; i <= 10; i++){
-        /*Serial.print("test#");
+        Serial.print("test#");
         Serial.print(i);
         Serial.print(" ");
-        Serial.println(analogRead(pin));*/
+        Serial.println(analogRead(pin));
         delay(100);
       }
   }
   if(componentType.equalsIgnoreCase("BUTTON")){
     Button button(_component.getPin()); //May be wasted memory
+    Serial.println("Press the button to test");
     for(int i = 0; i < 150; i++){
       if(button.isPressed()) {
+        Serial.println("The button was pressed");
         break;
       }
       delay(200);

--- a/src/ComponentTester.cpp
+++ b/src/ComponentTester.cpp
@@ -28,7 +28,7 @@ void ComponentTester::testPin(){
   if(componentType.equalsIgnoreCase("PHOTORESISTOR")){
     for(int i = 1; i <= 10; i++){
         if(Properties::DEBUGGING_ACTIVE) {
-          Serial.print("test# " + i + ": ");
+          Serial.print(String("test# ") + i + ": ");
           Serial.println(analogRead(pin));
         }
         delay(100);

--- a/src/ComponentTester.cpp
+++ b/src/ComponentTester.cpp
@@ -27,10 +27,10 @@ void ComponentTester::testPin(){
   }
   if(componentType.equalsIgnoreCase("PHOTORESISTOR")){
     for(int i = 1; i <= 10; i++){
-        Serial.print("test#");
-        Serial.print(i);
-        Serial.print(" ");
-        Serial.println(analogRead(pin));
+        if(Properties::DEBUGGING_ACTIVE) {
+          Serial.print("test# " + i + ": ");
+          Serial.println(analogRead(pin));
+        }
         delay(100);
       }
   }
@@ -39,7 +39,7 @@ void ComponentTester::testPin(){
     Serial.println("Press the button to test");
     for(int i = 0; i < 150; i++){
       if(button.isPressed()) {
-        Serial.println("The button was pressed");
+        if(Properties::DEBUGGING_ACTIVE) Serial.println("The button was pressed");
         break;
       }
       delay(200);

--- a/src/ComponentTester.h
+++ b/src/ComponentTester.h
@@ -6,6 +6,7 @@
 
 #include "Arduino.h"
 #include "Component.h"
+#include "Properties.h"
 
 class ComponentTester{
 private:

--- a/src/LED.h
+++ b/src/LED.h
@@ -6,6 +6,7 @@
 
 #include "Arduino.h"
 #include "Component.h"
+#include "Properties.h"
 
 class LED : public Component {
 public:

--- a/src/Laser.h
+++ b/src/Laser.h
@@ -6,6 +6,7 @@
 
 #include "Arduino.h"
 #include "Component.h"
+#include "Properties.h"
 
 class Laser : public Component {
 public:

--- a/src/Photoresistor.h
+++ b/src/Photoresistor.h
@@ -6,6 +6,7 @@
 
 #include "Arduino.h"
 #include "Component.h"
+#include "Properties.h"
 
 class Photoresistor : public Component {
 public:

--- a/src/Properties.cpp
+++ b/src/Properties.cpp
@@ -12,7 +12,7 @@
 #include "Properties.h"
 
 // ********** GENERAL ********** //
-boolean Properties::DEBUGGING_ACTIVE = true;
+boolean Properties::DEBUGGING_ACTIVE = false;
 int Properties::BAUD_RATE = 9600;
 
 // ********** MODULES ********** //

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,10 +53,12 @@ void setup() {
 void loop(){
   if(not alarm->isArmed()){
     if(alarm->isButtonPressed()){
+      SerialComm::sendLogMessage("Alarm Armed");
       alarm->arm();
     }
   } else {
     if(alarm->isTripped()){
+      SerialComm::sendLogMessage("Alarm Tripped");
       alarm->trigger();
     }
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,12 +53,12 @@ void setup() {
 void loop(){
   if(not alarm->isArmed()){
     if(alarm->isButtonPressed()){
-      SerialComm::sendLogMessage("Alarm Armed");
+      if(Properties::MODULE_PI) SerialComm::sendLogMessage("Alarm Armed");
       alarm->arm();
     }
   } else {
     if(alarm->isTripped()){
-      SerialComm::sendLogMessage("Alarm Tripped");
+      if(Properties::MODULE_PI) SerialComm::sendLogMessage("Alarm Tripped");
       alarm->trigger();
     }
   }


### PR DESCRIPTION
We only want to send a bunch of debug logging statements if it is configured in Properties.cpp to be turned on. This change adds checks before each print statement to see whether it is enabled and only log if it is.

It also adds a reference to the Properties.h file to those classes which didn't have it yet (even if they aren't currently debug logging anything).

I reverted (most of) the original change which took these out and then added the checks mentioned above.

Note that **Debug Logging** is now  **disabled by default**. The assumption here is that in a 'production' install, it is assumed that you don't need that constant stream of data happening and would only want to turn that on manually when you need to troubleshoot a device. Having it turned on is the _exception_, not the _rule_.