### PR TITLE
Add Defn. of Execute Commands and added Comment Convention

### DIFF
--- a/docs/development/logging.md
+++ b/docs/development/logging.md
@@ -24,19 +24,36 @@ The following are a few examples of some messages which might be sent and what t
 * `30025` = This message would represent a `3 - Data` Type command. Since this is not a `Log` Type of command, the `Log Level` is irrelevant and thus a `0 - N/A` is given. The Details for this command are `025`. The intention is for you, the receiver, to execute this command. Perhaps it is meant to represent a command such as `Arm` or `Disarm`.
 
 
+Developer Code Comment Convention
+---------------------------------
+Whenever a message is sent, it should have the code's translation included on the same line where the code is being sent. This will enable an easier time for other developers coming in at a future date and being able to more easily parse what is going on with the message being sent.
+
+Example:
+```c++
+Serial.write(13514);  // 13514 = Log, Debug, Component Configured on Pin 14
+```
+This should hold true for both the Java and the C++ sides of the code.
+
+Where possible, especially in Java, a value should be defined as a member variable with a descriptive name OR be 'built' using enum (or similar) values, all with descriptive names, so that the code can easily be translated by another developer.
+
+
 Message Translation Chart
 -------------------------
 | Type [0-9] | Log Level  [0-9] | Details  [000-999] |
 | ----------- | ---------------- | ------------------- |
 | 0 - N/A     | 0 - N/A          | 000 - N/A            |
-| 1 - Log     | 1 - Error        | 001 - Something      |
-| 2 - Data    | 2 - Warn         | 002 - Something else |
-| 3 - Command | 3 - Debug        | 003 - Even more      |
-| 4 - Error   | 4 - Info         | 514 - Component Configured on Pin 14 |
-| 5 - Request | 5 - Trace        | 515 - Component Configured on Pin 15 |
-| | | 516 - ... |
-| | | 703 - Execute Command - Arm |
+| 1 - Log     | 1 - Error        | 001 - Execute Command: Arm |
+| 2 - Data    | 2 - Warn         | 002 - Execute Command: Disarm |
+| 3 - Command | 3 - Debug        | 003 - Execute Command: Silence |
+| 4 - Error   | 4 - Info         | 003 - Execute Command: Calibrate |
+| 5 - Request | 5 - Trace        | 514 - [EXAMPLE] Component Configured on Pin 14 |
+| | | 515 - [EXAMPLE] Component Configured on Pin 15 |
+| | | 516 - [EXAMPLE] ... |
 
-Notes:
+**Details Block Definitions:**
+* [001 - 009] - Reserved for Commands intended for the Alarm (Arduino) to execute.
+* []
+
+**Notes:**
 * In general, you should never send a message of Type `0`. That really just wouldn't make any sense...
 * `Log Level` is only relevant when a `Log` Type message is sent. In all other cases a `0 - N/A` should be passed.


### PR DESCRIPTION
I've added the definition for the 4 commands currently defined in the Ardunino's code to handle.

I also added a Comment Convention that we should follow as we start working on the refactor for the logging, etc. Following this will help save a little time when a developer is lookng at the code to not have to go look things up in the table and instead can just see it documented right in the code.