### PR TITLE
Move Component Testing Code to Alarm Class

### DIFF
--- a/docs/development/logging.md
+++ b/docs/development/logging.md
@@ -45,8 +45,11 @@ Message Translation Chart
 | 1 - Log     | 1 - Error        | 001 - Execute Command: Arm |
 | 2 - Data    | 2 - Warn         | 002 - Execute Command: Disarm |
 | 3 - Command | 3 - Debug        | 003 - Execute Command: Silence |
-| 4 - Error   | 4 - Info         | 003 - Execute Command: Calibrate |
-| 5 - Request | 5 - Trace        | 514 - [EXAMPLE] Component Configured on Pin 14 |
+| 4 - Error   | 4 - Info         | 004 - Execute Command: Calibrate |
+| 5 - Request | 5 - Trace        | 005 - Execute Command: Trigger |
+| | | 006 - Execute Command: Reset Calibration |
+| | | 007 - Execute Command: Test Components |
+| | | 514 - [EXAMPLE] Component Configured on Pin 14 |
 | | | 515 - [EXAMPLE] Component Configured on Pin 15 |
 | | | 516 - [EXAMPLE] ... |
 

--- a/src/Alarm.cpp
+++ b/src/Alarm.cpp
@@ -73,7 +73,7 @@ void Alarm::arm(){
   if (!this->isReadyToArm()){
    Logger::Log("Alarm failed to arm");
    this->alertFailedAction();
-   _laser->off();
+   if(!this->isArmed()) _laser->off();
  } else {
    this->alertSuccessfulAction();
     Logger::Log("Alarm sucessfully armed");

--- a/src/Alarm.cpp
+++ b/src/Alarm.cpp
@@ -73,6 +73,7 @@ void Alarm::arm(){
   if (!this->isReadyToArm()){
    Logger::Log("Alarm failed to arm");
    this->alertFailedAction();
+   _laser->off();
  } else {
    this->alertSuccessfulAction();
     Logger::Log("Alarm sucessfully armed");

--- a/src/Alarm.cpp
+++ b/src/Alarm.cpp
@@ -11,6 +11,7 @@
 #include "Button.h"
 #include "Alarm.h"
 #include "Logger.h"
+#include "ComponentTester.h"
 
 Alarm::Alarm(){
   Logger::Log("Alarm has been created");
@@ -28,6 +29,18 @@ void Alarm::calibrate(){
     _isCalibrated = true;
   }
   _laser->off();
+}
+
+void Alarm::testBoardComponents(){
+  ComponentTester tester(_greenLED);
+  tester.testPin();
+  tester.testComponent(_redLED);
+  tester.testComponent(_alarmLED);
+  tester.testComponent(_photoR);
+  tester.testComponent(_buzzer);
+  tester.testComponent(_laser);
+  //tester.testComponent(_armButton);
+
 }
 
 void Alarm::determineBasePhotoresistorReading(){

--- a/src/Alarm.cpp
+++ b/src/Alarm.cpp
@@ -32,6 +32,7 @@ void Alarm::calibrate(){
 }
 
 void Alarm::testBoardComponents(){
+  if (isArmed()) disarm();
   ComponentTester tester(_greenLED);
   tester.testPin();
   tester.testComponent(_redLED);

--- a/src/ComponentTester.cpp
+++ b/src/ComponentTester.cpp
@@ -12,14 +12,14 @@ ComponentTester::ComponentTester() {
   Logger::Log("Default ComponentTester Constructor");
 }
 
-ComponentTester::ComponentTester(Component component){
+ComponentTester::ComponentTester(Component* component){
   Logger::Log("ComponentTester Constructor");
   _component = component;
 }
 
 void ComponentTester::testPin(){
-  String componentType = _component.getComponentType();
-  int pin = _component.getPin();
+  String componentType = _component->getComponentType();
+  int pin = _component->getPin();
   if(componentType.equalsIgnoreCase("LED") ||
       componentType.equalsIgnoreCase("LASER")){
       digitalWrite(pin, HIGH);
@@ -38,7 +38,7 @@ void ComponentTester::testPin(){
       }
   }
   if(componentType.equalsIgnoreCase("BUTTON")){
-    Button button(_component.getPin()); //May be wasted memory
+    Button button(_component->getPin()); //May be wasted memory
     for(int i = 0; i < 150; i++){
       if(button.isPressed()) {
         Logger::Log("The button was pressed");
@@ -49,15 +49,11 @@ void ComponentTester::testPin(){
   }
 }
 
-void ComponentTester::setComponent(Component component){
+void ComponentTester::setComponent(Component* component){
   _component = component;
 }
 
-void ComponentTester::testComponent(Component component){
+void ComponentTester::testComponent(Component* component){
   setComponent(component);
   testPin();
-}
-
-Component ComponentTester::getComponent(){
-  return _component;
 }

--- a/src/ComponentTester.h
+++ b/src/ComponentTester.h
@@ -10,16 +10,15 @@
 
 class ComponentTester{
 private:
-  Component _component;
+  Component* _component;
   int _millisOn = 500;
   int _millisOff = 100;
 public:
-  ComponentTester(Component component);
+  ComponentTester(Component* component);
   ComponentTester();
   void testPin();
-  void testComponent(Component component);
-  void setComponent(Component component);
-  Component getComponent();
+  void testComponent(Component* component);
+  void setComponent(Component* component);
 };
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,32 +16,12 @@ CommandListener* commandListener;
 #include "module_WIFI\Wifi.h"
 Wifi* wifi;
 
-//Test each of the components
-void testBoardComponents(){
-  LED greenLED(2);
-  LED redLED(3);
-  LED alarmLED(4);
-  Photoresistor photoR(A0);
-  Buzzer buzzer(6);
-  Button armButton(7);
-  Laser laser(8);
-
-  ComponentTester tester(greenLED);
-  tester.testPin();
-  tester.testComponent(redLED);
-  tester.testComponent(alarmLED);
-  tester.testComponent(photoR);
-  tester.testComponent(buzzer);
-  tester.testComponent(laser);
-  //tester.testComponent(armButton);
-}
-
 void setup() {
   Serial.begin(Properties::BAUD_RATE);
-  testBoardComponents();
   alarm = new Alarm();
+  if(not Properties::MODULE_PI) alarm->testBoardComponents();
   commandListener = new CommandListener(alarm);
-  alarm->calibrate();
+  if(not Properties::MODULE_PI) alarm->calibrate();
 
   if (Properties::MODULE_WIFI) {
     wifi = new Wifi(Properties::WIFI_RX_PIN, Properties::WIFI_TX_PIN);

--- a/src/module_PI/Arduino_Uno/CommandListener.cpp
+++ b/src/module_PI/Arduino_Uno/CommandListener.cpp
@@ -54,5 +54,8 @@ void CommandListener::executeCommand(byte* commandBytes){
     case 30006:
       alarm->resetCalibration();
       break;
+    case 30007:
+      alarm->testBoardComponents();
+      break;
   }
 }

--- a/src/module_PI/Arduino_Uno/CommandListener.cpp
+++ b/src/module_PI/Arduino_Uno/CommandListener.cpp
@@ -15,7 +15,7 @@ CommandListener::CommandListener(Alarm* alarm){
 }
 
 void CommandListener::executeCommandIfAvailable(){
-  if(Serial.available() > SIZE_OF_DATAPACKET_IN_BYTES){
+  if(Serial.available() >= SIZE_OF_DATAPACKET_IN_BYTES){
     for(int i = 0; i < SIZE_OF_DATAPACKET_IN_BYTES; i++){
       commandBytes[i] = Serial.read();
     }

--- a/src/module_PI/Raspberry_PI/PiApp.java
+++ b/src/module_PI/Raspberry_PI/PiApp.java
@@ -13,6 +13,12 @@ public class PiApp {
 		SerialOutput output = new SerialOutput();
 		
 		pause(10000);
+		output.sendTestComponentsPacket();
+		output.sendCalibratePacket();
+		output.sendArmPacket();
+		output.sendTriggerPacket();
+		output.sendSilencePacket();
+		
 		while(true){
 			output.sendArmPacket();
 			pause(5000);

--- a/src/module_PI/Raspberry_PI/SerialOutput.java
+++ b/src/module_PI/Raspberry_PI/SerialOutput.java
@@ -38,4 +38,10 @@ public class SerialOutput extends SerialComm {
 		byte[] buffer = {3,0,0,0,6};// 30006 = Command, NA, Execute Command: ResetCalibration
 		comPort.writeBytes(buffer, SIZE_OF_DATAPACKET_IN_BYTES);	
 	}
+	
+	public void sendTestComponentsPacket(){
+		byte[] buffer = {3,0,0,0,7};// 30007 = Command, NA, Execute Command: TestComponents
+		comPort.writeBytes(buffer, SIZE_OF_DATAPACKET_IN_BYTES);	
+		
+	}
 }


### PR DESCRIPTION
I moved the test components code over to the Alarm class to allow all alarm actions to be controlled via the Raspberry PI if that module is connected. It also eliminated the need to make more of the component objects in memory by just utilizing the already-created objects in the Alarm class. 

Now the alarm can run standalone or it can run as a slave to the Raspberry PI. 