### PR TITLE
Added IntelliJ project files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,15 @@
 .classpath
 factoryConfiguration.json
 
+
+### IntelliJ ###
+.idea/*
+.idea_modules/
+*.iws
+*.iml
+/out/
+
+
 ### Eclipse ###
 
 .metadata


### PR DESCRIPTION
My Java IDE of choice is [IntelliJ](https://www.jetbrains.com/idea/). Its project files are different from those created by Eclipse, which other team members are using, so I needed to add IntelliJ's project files to the `.gitignore` files so that they don't get committed.