### PR TITLE
Utilize PacketLogLevel and PacketType Enums

### DIFF
--- a/src/module_PI/Raspberry_PI/DataPacket.java
+++ b/src/module_PI/Raspberry_PI/DataPacket.java
@@ -6,11 +6,16 @@ public class DataPacket {
 	private byte[] packetCodeByteArray;
 	private int packetCodeInt;
 	private final int SIZE_OF_DATAPACKET_IN_BYTES = 5;
+	private final int PACKET_TYPE_INDEX = 0;
+	private final int LOG_LEVEL_INDEX = 1;
+	private PacketLogLevel packetLogLevel;
+	private PacketType packetType;
 
 	public DataPacket(int packetContents) {
 		packetCodeByteArray = new byte[SIZE_OF_DATAPACKET_IN_BYTES];
 		packetCodeInt = packetContents;
 		parseIntToByteArray(packetContents, SIZE_OF_DATAPACKET_IN_BYTES - 1);
+		parseTypeAndLogLevelFromByteArray();
 	}
 	
 	private void parseIntToByteArray(int packetCode, int index){
@@ -22,16 +27,31 @@ public class DataPacket {
 	public DataPacket(byte[] packetContents) {
 		packetCodeByteArray = Arrays.copyOf(packetContents, packetContents.length);
 		packetCodeInt = convertByteArrayToInt(packetContents);
+		parseTypeAndLogLevelFromByteArray();
 	}
 	
 	private int convertByteArrayToInt(byte[] packetContents){
 		int total = 0;
-		int multiplier = 10000;
-		for(int i = 0; i < 5; i++){
+		int multiplier = (int) Math.pow(10,  SIZE_OF_DATAPACKET_IN_BYTES - 1);
+		for(int i = 0; i < SIZE_OF_DATAPACKET_IN_BYTES; i++){
 			total += packetContents[i] * multiplier;
 			multiplier /= 10;
 		}
 		return total;
+	}
+	
+	private void parseTypeAndLogLevelFromByteArray(){
+		if(packetCodeByteArray == null) throw new NullPointerException("packetCodeByteArray hasn't been determined yet.");
+		parsePacketTypeFromByteArray();
+		parseLogLevelFromByteArray();
+	}
+	
+	private void parsePacketTypeFromByteArray(){
+		packetType = PacketType.getPacketTypeFromByte(packetCodeByteArray[PACKET_TYPE_INDEX]);		
+	}
+	
+	private void parseLogLevelFromByteArray(){
+		packetLogLevel = PacketLogLevel.getLogLevelFromByte(packetCodeByteArray[LOG_LEVEL_INDEX]);
 	}
 	
 	public int getSizeInBytes(){
@@ -44,5 +64,13 @@ public class DataPacket {
 	
 	public int getPacketAsInt(){
 		return packetCodeInt;
+	}
+	
+	public PacketLogLevel getPacketLogLevel(){
+		return packetLogLevel;
+	}
+	
+	public PacketType getPacketType(){
+		return packetType;
 	}
 }

--- a/src/module_PI/Raspberry_PI/PacketLogLevel.java
+++ b/src/module_PI/Raspberry_PI/PacketLogLevel.java
@@ -23,6 +23,7 @@ public enum PacketLogLevel {
 	
 	@Override
 	public String toString(){
-		return packetTypeStrings[packetLogLevelByte];
+		int packetTypeStringIndex = packetLogLevelByte - 1;
+		return packetTypeStrings[packetTypeStringIndex];
 	}
 }

--- a/src/module_PI/Raspberry_PI/PacketType.java
+++ b/src/module_PI/Raspberry_PI/PacketType.java
@@ -23,6 +23,7 @@ public enum PacketType {
 	
 	@Override
 	public String toString(){
-		return packetTypeStrings[packetTypeByte];
+		int packetTypeStringIndex = packetTypeByte - 1;
+		return packetTypeStrings[packetTypeStringIndex];
 	}
 }


### PR DESCRIPTION
I made it so that the DataPacket can utilize the PacketLogLevel and PacketType enums and correctly parse them from either an int or a byte array. I also fixed a few off by one errors. 