### PR TITLE
Made wifi setup sound a 'waiting' tone on the alarm

### DIFF
--- a/docs/circuit_diagrams/module_WIFI/README.md
+++ b/docs/circuit_diagrams/module_WIFI/README.md
@@ -122,6 +122,7 @@ By default, the ESP8266 communicates at `115200` baud which is too fast for the 
 3. Build then upload `main.cpp`
 4. After the code has uploaded, launch the Terminal - make sure baud rate is set to `115200`
 5. In the Terminal window, type `AT` and press Enter
+  * _If you have issues with this step, try unplugging and plugging back in the Arduino and relaunching the Serial Monitor. Also try relaunching Atom. It appears that it sometimes just gets into a state where it doesn't fully recognize you are sending commands through it._
 6. You should get back a message `OK`
 7. In the Terminal window, type `AT+UART_DEF=9600,8,1,0,0` and press Enter
 8. In the terminal window you should see the cursor moving and either blank or garbled characters will be displayed.

--- a/src/Alarm.cpp
+++ b/src/Alarm.cpp
@@ -6,10 +6,6 @@
   @author Christopher Nash, Jason Bruderer, David Tille, Tyler Jacobs
   @version To be Determined
 */
-
-/**
-
-*/
 #include "Arduino.h"
 #include "Component.h"
 #include "LED.h"
@@ -63,6 +59,7 @@ void Alarm::testBoardComponents(){
   //tester.testComponent(_armButton);
 
 }
+
 /**
   Determines a base of the photorsistor at normal light levels and then
     determines the value of the photorsistor when the laser is on it.
@@ -83,6 +80,7 @@ void Alarm::determineBasePhotoresistorReading(){
   Serial.write(13101); // 13101 = Log, Debug, Alarm base photorsistor reading determined
   _laser->on();
 }
+
 /**
   Makes the buzzer produce the Negative tone
 */
@@ -91,6 +89,7 @@ void Alarm::alertFailedAction(){
   _buzzer->soundNegativeTone();
   _redLED->flash(1000);
 }
+
 /**
   Makes the buzzer produce the Affirmative tone
 */
@@ -99,6 +98,18 @@ void Alarm::alertSuccessfulAction(){
   _buzzer->soundAffirmativeTone();
   _greenLED->flash(1000);
 }
+
+/**
+  Make an alert sound with lights to indicate the alarm is waiting.
+*/
+void Alarm::alertWaitingAction(){
+  _redLED->flash(1000);
+  _buzzer->soundTone(600, 300);
+  _greenLED->flash(1000);
+  _buzzer->soundTone(600, 300);
+  _redLED->flash(1000);
+}
+
 /**
   Turns the LASER on and if it fails isReadyToArm turns it back off to as it the
     Alarm class needs to be calibrated again and leaves it on and sets isArmed
@@ -121,6 +132,7 @@ void Alarm::arm(){
    _isArmed = true;
  }
 }
+
 /**
   @return returns true if the isArmed is not armed and isCalibrated is
     calibrated, and isTripped and isTriggered are not activated
@@ -131,12 +143,14 @@ bool Alarm::isReadyToArm(){
         && !this->isTripped()
         && !this->isTriggered());
 }
+
 /**
   Getter for the param _isArmed
 */
 bool Alarm::isArmed(){
   return _isArmed;
 }
+
 /**
   @return returns a true false based on whether or the reading taken is less
     than the _baseReading by 100
@@ -144,6 +158,7 @@ bool Alarm::isArmed(){
 bool Alarm::isTripped(){
   return (_photoR->takeReading() - 100 < _baseReading);
 }
+
 /**
   Sets the alarm to be triggered
   @param sets _isTriggered to be true
@@ -154,6 +169,7 @@ void Alarm::trigger(){
   _isTriggered = true;
   _isSilenced = false;
 }
+
 /**
   If _isSilenced is not set soundAlarmHighTone and soundAlarmLowTone are used
     to set tone high and low, also tells _redLED and _alarmLED to flash
@@ -164,6 +180,7 @@ void Alarm::soundOneAlarmCycle(){
   if (not this->_isSilenced) _buzzer->soundAlarmLowTone();
   _alarmLED->flash(300);
 }
+
 /**
   Disarms the alarm and sets the calibration to false to resetCalibration
   @param _isCalibrated is set to false
@@ -173,12 +190,14 @@ void Alarm::resetCalibration(){
   disarm();
   _isCalibrated = false;
 }
+
 /**
   @return _isTriggered getter
 */
 bool Alarm::isTriggered(){
   return _isTriggered;
 }
+
 /**
   Used to disarm the alarm
   @param _isTriggered is set to false
@@ -196,6 +215,7 @@ void Alarm::disarm(){
   _laser->off();
   Serial.write(13110); // 13110 = Log, Debug, Alarm is being disarmed
 }
+
 /**
   Silences the alarm by setting _isSilenced to true
 */
@@ -203,12 +223,14 @@ void Alarm::silence(){
   _isSilenced = true;
   Serial.write(13111); // 13111 = Log, Debug, Alarm is being silenced
 }
+
 /**
   @return getter for _isCalibrated
 */
 bool Alarm::isCalibrated(){
   return _isCalibrated;
 }
+
 /**
   @return getter for _armButton by using the isPressed function from Button
 */

--- a/src/Alarm.h
+++ b/src/Alarm.h
@@ -37,6 +37,9 @@ class Alarm{
     bool isReadyToArm();
     void soundOneAlarmCycle();
     void resetCalibration();
+    void alertFailedAction();
+    void alertSuccessfulAction();
+    void alertWaitingAction();
 
     /**
       @param _greenLED, _redLED, _alarmLED used for LEDs on the breadboard
@@ -67,8 +70,6 @@ class Alarm{
     int _baseReading = 0;
     int _threshold = 100;
     void determineBasePhotoresistorReading();
-    void alertFailedAction();
-    void alertSuccessfulAction();
   };
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,8 +23,9 @@ CommandListener* commandListener;
 
 #include "module_WIFI\WifiModule.h"
 WifiModule* wifiModule;
+
 /**
-  Setups the intial classes to be used like Alarm and Wifi
+  Sets up the intial classes to be used like Alarm and Wifi
 */
 void setup() {
   Serial.begin(Properties::BAUD_RATE);
@@ -34,10 +35,13 @@ void setup() {
   if(not Properties::MODULE_PI) alarm->calibrate();
 
   if (Properties::MODULE_WIFI) {
+    alarm->alertWaitingAction();
     wifiModule = new WifiModule();
     wifiModule->initialize();
+    alarm->alertSuccessfulAction();
   }
 }
+
 /**
   Looping command for active listening or what is happening on the Arduino.
     Listens to see if the alarm has been trigged, calibrated, or armed.
@@ -52,7 +56,7 @@ void loop(){
     if(alarm->isTripped() && not alarm->isTriggered()){
       alarm->trigger();
       if (Properties::MODULE_WIFI) {
-        wifiModule->sendNotification();
+        wifiModule->sendNotification(); // TODO: This is blocking. See https://github.com/Lastrellik/Calico-Home-Security/issues/62
       }
     }
   }


### PR DESCRIPTION
This change make a 'waiting' sound trigger before the wifi module connects to wireless and a 'success' sound trigger when it successfully connects.

While debugging / working on my wifi module I realized that after the alarm goes through its normal setup procedures it turns control over to the wifi module to do its thing. It was difficult to know when / if it had finally connected to wifi (_which seems to vary anywhere from 5 seconds to almost 30 seconds..._) so I added a way that you can hear and see that it is starting the wifi setup as well as hear and see when it successfully connected.

Unfortunately, once I hand over control to the ESP8266's library I am using things are out of my control. I can't, for example, continue sound the tone every second or continue flashing an led. If we were in a place where we could do multi-threaded operations then I could do that. In theory, if I were to spend a whole bunch of time working on my own library, I could send the command to the ESP8266 chip to start connecting, return control back to the Arduino (since the ESP8266 is a microcontroller itself and can handle its own processing) and then come back periodically to check "Hey - are you connected yet?". But thats not the way these libraries for it are configured to work... So I'm out of luck on that.

So while not great, this at least gives _something_ to let the user know that something is happening....

_(PS - I added spaces above a bunch of the method comments and forgot to take that out before I committed so thats why you see a bunch of empty lines added.)_