### PR TITLE
Some improvements to the new Maven pom file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,10 +6,11 @@
 	<version>0.0.1-SNAPSHOT</version>
 	<name>Calico Home Security</name>
 	<build>
-		<sourceDirectory>src</sourceDirectory>
+		<sourceDirectory>src/module_PI/Raspberry_PI</sourceDirectory>
+		<!--<testSourceDirectory>src/module_PI/Raspberry_PI/JUnitTests</testSourceDirectory>--> <!-- TODO: Adjust tests so they don't rely on an Arduino being plugged in (should be mocked) and running then uncomment this line so that all unit tests are run at build time -->
 		<resources>
 			<resource>
-				<directory>src</directory>
+				<directory>src/module_PI/Raspberry_PI</directory>
 				<excludes>
 					<exclude>**/*.java</exclude>
 				</excludes>
@@ -20,8 +21,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.5.1</version>
 				<configuration>
-					<source />
-					<target />
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 		</plugins>
@@ -51,6 +52,11 @@
 			<groupId>javax.mail</groupId>
 			<artifactId>mail</artifactId>
 			<version>1.4</version>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.12</version>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
This change adds some minor changes to the new Maven pom.xml file.

- Specifies the Java version to use when compiling the code. It was unspecified but now lists Java 8 (1.8) as the copile target.
- Adds the junit dependency
- Specifies where the source directory is for the Raspberry Pi module. Before it was getting everything in the `src/` directory, including the c++ files, and including them in the `target` directory even though they weren't needed.

It is likely that the IDE you were using while developing (Eclipse?) defaulted to including the junit dependency automatically and sortof bypassing Maven. Same thing goes for the Java version. These changes just make those things explicit instead of controlled as a side effect of the IDE you are using.

Also note that I added an additional line that is commented out for `testSourceDirectory`. Because things in this project aren't really in their standard places based on Java project naming conventions, Maven didn't know where to look for the test files. If you run a `mvn test` (or `mvn install`) you will see that it launches a test cycle and spits out a message similar to `[INFO] skip non existing resourceDirectory .../Calico-Home-Security/src/test/resources`. The line that I added tells Maven where to go and look for the junit tests.

However, the tests currently rely on an Arduino being present in order to run. Not having one causes all the tests to fail. Since we aren't garunteed to have one of those at all times, that Arduino really should be mocked in the tests so that there isn't an external dependency on them. As such, I've left the line but commented it out and added a TODO message in it to correct that at some point in the future.