### PR TITLE
Added Laser Aiming Mode & Moved Trip Time to Properties

### DIFF
--- a/src/Properties.cpp
+++ b/src/Properties.cpp
@@ -13,7 +13,9 @@
 
 // ********** GENERAL ********** //
 boolean Properties::DEBUGGING_ACTIVE = false;                 // Set to `true` if you are troubleshooting an issue and want to see log output in your terminal window
+boolean Properties::LASER_AIMING_MODE = false;                // Setting to true will activate the laser during the setup phase of the alarm and leave it on until the button is pressed. This can be helpful when setting up the laser.
 int Properties::BAUD_RATE = 9600;                             // Normally shouldn't be changed. The only time you might need to is when working with an ESP8266 module. See the Wifi Module's README for more information.
+int Properties::ALARM_TRIPPED_TO_TRIGGERED_MILLIS = 30000;    // The amount of time between the alarm being tripped and it being triggered. Default is 30000 (30 seconds).
 
 // ********** MODULES ********** //
 boolean Properties::MODULE_BASE = true;                       // Normally set to `true`. This is only set to `false` if you are using the MINI module. This is the ONLY module which should be checked into the repo as `true`.

--- a/src/Properties.h
+++ b/src/Properties.h
@@ -18,7 +18,9 @@ class Properties {
   public:
     // ********** GENERAL ********** //
     static boolean DEBUGGING_ACTIVE;
+    static boolean LASER_AIMING_MODE;
     static int BAUD_RATE;
+    static int ALARM_TRIPPED_TO_TRIGGERED_MILLIS;
 
 
     // ********** MODULES ********** //

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,7 +21,6 @@ Alarm* alarm;
 CommandListener* commandListener;
 
 long timeAlarmHasBeenTrippedInMillis = 0;
-const long TIME_ALARM_CAN_BE_TRIPPED_IN_MILLIS = 30000;
 
 #include "module_WIFI/WifiModule.h"
 WifiModule* wifiModule;
@@ -36,6 +35,15 @@ TurretMASTER* turretMASTER;
 void setup() {
   Serial.begin(Properties::BAUD_RATE);
   alarm = new Alarm();
+
+  if(Properties::LASER_AIMING_MODE){
+    alarm->toggleLaser();
+    while(not alarm->isButtonPressed()) {
+      // Loop here until the button is pressed
+    }
+    alarm->toggleLaser();
+  }
+
   if(not Properties::MODULE_PI) alarm->testBoardComponents();
   commandListener = new CommandListener(alarm);
   if(not Properties::MODULE_PI) alarm->calibrate();
@@ -100,7 +108,7 @@ void loop(){
     long startTime = millis();
     alarm->alertWaitingAction();
     timeAlarmHasBeenTrippedInMillis += millis() - startTime;//Seconds it takes for the
-    if(timeAlarmHasBeenTrippedInMillis >= TIME_ALARM_CAN_BE_TRIPPED_IN_MILLIS){
+    if(timeAlarmHasBeenTrippedInMillis >= Properties::ALARM_TRIPPED_TO_TRIGGERED_MILLIS){
       alarm->trigger();
 
       if (Properties::MODULE_WIFI) {


### PR DESCRIPTION
* I moved the amount of time between Tripped and Triggered to be in the Properties files. This way it is easier to configure with all of the other application settings.

* It was very useful while setting up our demonstration for the Raspberry Pi to be able to turn on the laser and just leave it on. I implemented a similar mechanism for the base module so you can flip a flag in the Properties file and it will toggle the laser on and leave it on until you press the button. This will help in aiming.