### PR TITLE
Improved Wifi Connect Flow

### DIFF
--- a/src/Properties.cpp
+++ b/src/Properties.cpp
@@ -31,6 +31,7 @@ int Properties::WIFI_TX_PIN = 11;                             // The pin on the 
 String Properties::WIFI_SSID = "YOUR_SSID_HERE";              // The name (SSID) of your wireless access point.
 String Properties::WIFI_PASSWORD = "YOUR_WIRELESS_PASSWORD";  // The password to connect to your wireless network.
 String Properties::IFTTT_MAKER_KEY = "YOUR_IFTTT_MAKER_KEY";  // Key obtained from your IFTTT account. See `IFTTT Setup` instructions in the Wifi Module's README for more details.
+int Properties::WIFI_CONNECT_RETRY_COUNT = 3;                      // The number of times the Wifi module will attempt to connect before it fails.
 String Properties::IFTTT_MAKER_EVENT = "alarm_tripped";       // The IFTTT Maker's Event. See `IFTTT Setup` instructions in the Wifi Module's README for more details.
 String Properties::IFTTT_MAKER_URI = "maker.ifttt.com";       // The IFTTT Maker root URI. There is likely no need to change this until IFTTT changes the URI in the future.
 

--- a/src/Properties.h
+++ b/src/Properties.h
@@ -36,6 +36,7 @@ class Properties {
     static int WIFI_TX_PIN;
     static String WIFI_SSID;
     static String WIFI_PASSWORD;
+    static int WIFI_CONNECT_RETRY_COUNT;
     static String IFTTT_MAKER_KEY;
     static String IFTTT_MAKER_EVENT;
     static String IFTTT_MAKER_URI;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,10 +41,16 @@ void setup() {
   if(not Properties::MODULE_PI) alarm->calibrate();
 
   if (Properties::MODULE_WIFI) {
-    alarm->alertWaitingAction();
+    alarm->alertWaitingAction(); // Let the user know that we're preparing to connect
     wifiModule = new WifiModule();
     wifiModule->initialize();
-    alarm->alertSuccessfulAction();
+    if(wifiModule->isInitialized()) {
+      alarm->alertSuccessfulAction(); // Let the user know that everything is good
+    } else {
+      alarm->alertFailedAction();
+      alarm->alertFailedAction(); // Let the user know that something didn't go right
+      alarm->alertFailedAction();
+    }
   }
 
   if (Properties::MODULE_TURRET) {
@@ -103,7 +109,7 @@ void loop(){
     if(timeAlarmHasBeenTrippedInMillis >= TIME_ALARM_CAN_BE_TRIPPED_IN_MILLIS){
       alarm->trigger();
 
-      if (Properties::MODULE_WIFI) {
+      if (Properties::MODULE_WIFI && wifiModule->isInitialized()) {
         wifiModule->sendNotification(); // TODO: This is blocking. See https://github.com/Lastrellik/Calico-Home-Security/issues/62
       }
 

--- a/src/module_WIFI/WifiModule.h
+++ b/src/module_WIFI/WifiModule.h
@@ -17,6 +17,7 @@ class WifiModule {
     WifiModule(int baudRate);
     void setBaudRate(int baudRate);
     void initStatus();
+    boolean isInitialized();
     void checkStatusAndReinitIfNecessary();
     void initialize();
     void sendNotification();
@@ -27,6 +28,7 @@ class WifiModule {
     SoftwareSerial esp8266;
     int _baudRate = Properties::BAUD_RATE;
     int _status;
+    boolean _initialized = false;
 };
 
 #endif


### PR DESCRIPTION
I wasn't handling the case where I couldn't connect to wireless. This change allows a configurable number of retry attempts before returning, alerting the user that something is wrong, then continuing with the rest of the alarm functionality.