### PR TITLE
Resolve laser bug

### DIFF
--- a/src/Alarm.cpp
+++ b/src/Alarm.cpp
@@ -137,10 +137,12 @@ void Alarm::arm(){
     calibrated, and isTripped and isTriggered are not activated
 */
 bool Alarm::isReadyToArm(){
+  _laser->on();
   return(!this->isArmed()
-        && this->isCalibrated()
-        && !this->isTripped()
-        && !this->isTriggered());
+      && this->isCalibrated()
+      && !this->isTripped()
+      && !this->isTriggered()
+      && !this->isLaserBeamBroken());
 }
 
 /**


### PR DESCRIPTION
This patch is to resolve the [alarm arm](https://github.com/Lastrellik/Calico-Home-Security/issues/94) issue. Basically I threw a check in there to make sure the laser is where it needs to be before arming.