### PR TITLE
Added GitHub Profile Links to Contributor Names

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ About the Project
 Authors
 -------
 
-* Christopher Nash
-* Tyler Jacobs
-* Dave Tille
-* Jason Bruderer
+* [Christopher Nash](https://github.com/Zeustopher)
+* [Tyler Jacobs](https://github.com/Boomstick105)
+* [Dave Tille](https://github.com/sithboy)
+* [Jason Bruderer](https://github.com/Lastrellik)
 
 Background
 ----------


### PR DESCRIPTION
I added our GitHub Profile Links to each of our names in the Contributor Names list (because why not, right?)

(I was glancing at my Starred Repos and this was on there and I got a little sentimental. I'll have to go dig out my project and fire it up sometime after this semester is over.)